### PR TITLE
Remove highlights after puzzle change

### DIFF
--- a/src/pages/OneWordRushPage.tsx
+++ b/src/pages/OneWordRushPage.tsx
@@ -156,6 +156,7 @@ export const OneWordRushPage = () => {
     if (result.position) {
       setGrid(result.grid)
       setTimeLeft(30) // Reset timer for new word
+      setFoundWordPositions([]) // Clear highlighting from previous word
     } else {
       // Fallback if word placement fails
       generateNewPuzzle()


### PR DESCRIPTION
Remove persistent word highlighting in One Word Rush after new puzzle generation.

Previously, the `foundWordPositions` state, which controls cell highlighting, was not reset when a new puzzle was generated, causing highlights from previous words to persist.