### PR TITLE
Restore toolbar to word search hub

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -54,9 +54,9 @@ export const Layout = ({ children }: LayoutProps) => {
   const navigate = useNavigate()
   const location = useLocation()
 
-  // Check if we're on the word search page and on mobile for full-screen mode
-  const isWordSearchPage = location.pathname === '/word-search'
-  const showFullScreen = isWordSearchPage && isMobile
+  // Check if we're on a word search game page (not the hub) and on mobile for full-screen mode
+  const isWordSearchGamePage = location.pathname.startsWith('/word-search/') && location.pathname !== '/word-search'
+  const showFullScreen = isWordSearchGamePage && isMobile
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen)


### PR DESCRIPTION
Restore the toolbar to the word search hub page by correcting the condition that previously hid it on the hub instead of only on word search game pages.