### PR TITLE
Update home page layout

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,32 +26,7 @@ export const HomePage = () => {
       </Typography>
 
       <Grid container spacing={3}>
-        <Grid item xs={12} md={8}>
-          <Card elevation={2}>
-            <CardContent>
-              <Typography variant="h5" component="h2" gutterBottom>
-                🎉 What's This All About?
-              </Typography>
-              <Typography variant="body1" paragraph>
-                This is my personal playground for web development experiments! I use this space to 
-                try out new ideas, build fun interactive demos, and just have a good time coding.
-              </Typography>
-              
-              <Typography variant="body1" paragraph>
-                Think of it as a digital workbench where I "kitbash" different concepts together - 
-                borrowing ideas from here and there to create something new and interesting.
-              </Typography>
-
-              <Typography variant="body1">
-                Each demo page showcases different types of interactions and functionality. 
-                Some are practical (like the todo list), others are just for fun (like the games). 
-                Take a look around and see what catches your interest!
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        <Grid item xs={12} md={4}>
+        <Grid item xs={12}>
           <Card elevation={2}>
             <CardContent>
               <Typography variant="h5" component="h2" gutterBottom>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -17,7 +17,7 @@ export const HomePage = () => {
   return (
     <Box sx={{ p: 3 }}>
       <Typography variant="h3" component="h1" gutterBottom>
-        Welcome to Kitbash
+        kitbash - a bunch of different things stuck together
       </Typography>
       
       <Typography variant="h6" color="text.secondary" paragraph>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -21,8 +21,7 @@ export const HomePage = () => {
       </Typography>
       
       <Typography variant="h6" color="text.secondary" paragraph>
-        A simple web project where I experiment with different ideas and build interactive demos. 
-        Feel free to explore and play around!
+        there's no theme to the things in here, feel free to poke around
       </Typography>
 
       <Grid container spacing={3}>


### PR DESCRIPTION
Remove "What's this all about" section and update home page title for a cleaner, more descriptive landing.