### PR TITLE
Limit hidden word length to ten characters

### DIFF
--- a/src/pages/OneWordRushPage.tsx
+++ b/src/pages/OneWordRushPage.tsx
@@ -278,7 +278,9 @@ export const OneWordRushPage = () => {
   // Utility functions
   const getRandomWords = useCallback(() => {
     const allWords = [...easyWords, ...mediumWords, ...hardWords]
-    const shuffled = [...allWords]
+    // Filter out words longer than 10 characters to prevent display issues on mobile
+    const filteredWords = allWords.filter(word => word.length <= 10)
+    const shuffled = [...filteredWords]
     for (let i = shuffled.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1))
       ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]


### PR DESCRIPTION
Limit hidden words in One Word Rush to 10 characters or less to prevent grid deformation and off-screen content on mobile.