### PR TITLE
Fix mobile word search highlight path

### DIFF
--- a/src/hooks/useSelectionLineRenderer.tsx
+++ b/src/hooks/useSelectionLineRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useMemo } from 'react'
+import { useCallback, useRef, useEffect, useState } from 'react'
 import { Box } from '@mui/material'
 
 interface Cell {
@@ -31,32 +31,91 @@ export const useSelectionLineRenderer = (options: SelectionLineRendererOptions) 
   } = options
 
   const svgRef = useRef<SVGSVGElement>(null)
+  const [gridDimensions, setGridDimensions] = useState({ width: 400, height: 400 })
+  const [shouldUpdate, setShouldUpdate] = useState(0)
 
-  // Memoize grid element and dimensions to avoid repeated DOM queries
-  const gridInfo = useMemo(() => {
-    const gridElement = document.querySelector('[data-grid="true"]') as HTMLElement
-    const gridRect = gridElement?.getBoundingClientRect()
-    return {
-      element: gridElement,
-      width: gridRect?.width || 400,
-      height: gridRect?.height || 400
+  // Force re-measurement on mobile when needed
+  const forceUpdate = useCallback(() => {
+    setShouldUpdate(prev => prev + 1)
+  }, [])
+
+  // Handle resize events and orientation changes on mobile
+  useEffect(() => {
+    const handleResize = () => {
+      // Small delay to ensure DOM has updated
+      setTimeout(() => {
+        forceUpdate()
+      }, 100)
     }
-  }, [isDragging, grid.length]) // Re-calculate when dragging state changes or grid size changes
 
-  // Get actual cell center coordinates using DOM measurements
+    const handleOrientationChange = () => {
+      // Longer delay for orientation changes
+      setTimeout(() => {
+        forceUpdate()
+      }, 300)
+    }
+
+    window.addEventListener('resize', handleResize)
+    window.addEventListener('orientationchange', handleOrientationChange)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('orientationchange', handleOrientationChange)
+    }
+  }, [forceUpdate])
+
+  // Get grid dimensions with better mobile support
+  const updateGridDimensions = useCallback(() => {
+    const gridElement = document.querySelector('[data-grid="true"]') as HTMLElement
+    if (gridElement) {
+      // Use requestAnimationFrame to ensure measurements are accurate
+      requestAnimationFrame(() => {
+        const gridRect = gridElement.getBoundingClientRect()
+        if (gridRect.width > 0 && gridRect.height > 0) {
+          setGridDimensions({
+            width: gridRect.width,
+            height: gridRect.height
+          })
+        }
+      })
+    }
+  }, [])
+
+  // Update dimensions when grid changes or on mobile updates
+  useEffect(() => {
+    if (isMobile) {
+      // Add a small delay for initial mobile rendering
+      const timer = setTimeout(() => {
+        updateGridDimensions()
+      }, 50)
+      return () => clearTimeout(timer)
+    } else {
+      updateGridDimensions()
+    }
+  }, [updateGridDimensions, grid.length, shouldUpdate, isMobile])
+
+  // Get actual cell center coordinates with improved mobile support
   const getCellCenterCoordinates = useCallback((row: number, col: number) => {
     const cellElement = document.querySelector(`[data-cell="${row}-${col}"]`) as HTMLElement
-    if (!cellElement || !gridInfo.element) return null
+    const gridElement = document.querySelector('[data-grid="true"]') as HTMLElement
+    
+    if (!cellElement || !gridElement) return null
 
+    // Use requestAnimationFrame for better mobile compatibility
     const cellRect = cellElement.getBoundingClientRect()
-    const gridRect = gridInfo.element.getBoundingClientRect()
+    const gridRect = gridElement.getBoundingClientRect()
+
+    // Ensure we have valid measurements
+    if (cellRect.width === 0 || cellRect.height === 0 || gridRect.width === 0 || gridRect.height === 0) {
+      return null
+    }
 
     // Calculate center position relative to the grid container
     const centerX = cellRect.left + cellRect.width / 2 - gridRect.left
     const centerY = cellRect.top + cellRect.height / 2 - gridRect.top
 
     return { x: centerX, y: centerY }
-  }, [gridInfo.element])
+  }, [])
 
   const renderSelectionLine = useCallback(() => {
     if (!isDragging || !startCell || !currentCell) return null
@@ -74,7 +133,7 @@ export const useSelectionLineRenderer = (options: SelectionLineRendererOptions) 
     // Calculate dynamic stroke width based on actual cell size
     const cellElement = document.querySelector(`[data-cell="${startCell.row}-${startCell.col}"]`) as HTMLElement
     const cellSize = cellElement ? Math.min(cellElement.offsetWidth, cellElement.offsetHeight) : (isMobile ? 32 : 40)
-    const dynamicStrokeWidth = cellSize * 0.8 // 80% of cell size for good visual coverage
+    const dynamicStrokeWidth = Math.max(cellSize * 0.8, isMobile ? 20 : 24) // Ensure minimum stroke width on mobile
     
     const currentStrokeColor = isValidDirection ? strokeColor : 'rgba(255, 152, 0, 0.6)'
 
@@ -92,13 +151,16 @@ export const useSelectionLineRenderer = (options: SelectionLineRendererOptions) 
       >
         <svg
           ref={svgRef}
-          width={gridInfo.width}
-          height={gridInfo.height}
+          width={gridDimensions.width}
+          height={gridDimensions.height}
           style={{
             position: 'absolute',
             top: 0,
             left: 0,
-            pointerEvents: 'none'
+            pointerEvents: 'none',
+            // Force hardware acceleration on mobile
+            transform: 'translateZ(0)',
+            backfaceVisibility: 'hidden'
           }}
         >
           <line
@@ -124,8 +186,8 @@ export const useSelectionLineRenderer = (options: SelectionLineRendererOptions) 
     strokeColor,
     opacity,
     getCellCenterCoordinates,
-    gridInfo.width,
-    gridInfo.height
+    gridDimensions.width,
+    gridDimensions.height
   ])
 
   return {


### PR DESCRIPTION
Fix word search highlight paths not rendering on mobile devices.

The issue stemmed from timing discrepancies with `getBoundingClientRect()` and static grid dimension caching on mobile, preventing accurate line rendering during viewport changes or initial load.